### PR TITLE
Fix type usage

### DIFF
--- a/uce.portal/pom.xml
+++ b/uce.portal/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javaVersion>21</javaVersion>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>

--- a/uce.portal/uce.common/pom.xml
+++ b/uce.portal/uce.common/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javaVersion>21</javaVersion>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/HibernateConf.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/HibernateConf.java
@@ -20,6 +20,7 @@ import org.texttechnologylab.models.topic.TopicWord;
 import org.texttechnologylab.models.topic.UnifiedTopic;
 
 import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @EnableTransactionManagement
@@ -82,7 +83,7 @@ public class HibernateConf {
         return metadata.getSessionFactoryBuilder().build();
     }
 
-    private static HashMap<Object, Object> getSettings() {
+    private static Map<Object, Object> getSettings() {
         var settings = new HashMap<>();
         var config = new CommonConfig();
         settings.put("connection.driver_class", config.getPostgresqlProperty("connection.driver_class"));

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
@@ -15,10 +15,7 @@ import org.texttechnologylab.models.biofid.BiofidTaxon;
 import org.texttechnologylab.models.corpus.links.AnnotationToDocumentLink;
 import org.texttechnologylab.models.corpus.links.DocumentLink;
 import org.texttechnologylab.models.corpus.links.DocumentToAnnotationLink;
-import org.texttechnologylab.models.corpus.links.Link;
 import org.texttechnologylab.models.negation.*;
-import org.texttechnologylab.models.search.AnnotationSearchResult;
-import org.texttechnologylab.models.search.PageSnippet;
 import org.texttechnologylab.models.topic.TopicValueBase;
 import org.texttechnologylab.models.topic.TopicValueBaseWithScore;
 import org.texttechnologylab.models.topic.UnifiedTopic;
@@ -370,8 +367,8 @@ public class Document extends ModelBase implements WikiModel, Linkable {
         int offsetStart = Math.max(annotation.getBegin() - 150, 0);
         int offsetEnd = Math.min(annotation.getEnd() + 150, annotation.getBegin() + 500);
         String snippet = getFullTextSnippetCharOffset(offsetStart, offsetEnd);
-        List<ArrayList<Integer>> offsetList = new ArrayList<>();
-        ArrayList<Integer> offsetArray = new ArrayList<>();
+        List<List<Integer>> offsetList = new ArrayList<>();
+        List<Integer> offsetArray = new ArrayList<>();
         offsetArray.add(annotation.getBegin());
         offsetArray.add(annotation.getEnd());
         offsetList.add(offsetArray);
@@ -380,12 +377,12 @@ public class Document extends ModelBase implements WikiModel, Linkable {
 
     public String getFullTextSnippetOffsetList(TemplateModel model) throws TemplateModelException {
         if (model instanceof TemplateSequenceModel) {
-            List<ArrayList<Integer>> offsetList = FreemarkerUtils.convertToNestedIntegerList((TemplateSequenceModel) model);
+            List<List<Integer>> offsetList = FreemarkerUtils.convertToNestedIntegerList((TemplateSequenceModel) model);
 
 
             int minBegin = 999999999;
             int maxEnd = 0;
-            for (ArrayList<Integer> offset : offsetList) {
+            for (List<Integer> offset : offsetList) {
                 if (minBegin > offset.getFirst()) {
                     minBegin = offset.getFirst();
                 }
@@ -393,7 +390,7 @@ public class Document extends ModelBase implements WikiModel, Linkable {
                     maxEnd = offset.getLast();
                 }
             }
-            for (ArrayList<Integer> pair : offsetList) {
+            for (List<Integer> pair : offsetList) {
                 for (int i = 0; i < pair.size(); i++) {
                     pair.set(i, pair.get(i) - Math.max(minBegin - 100, 0));
                 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/links/LinkableRegistry.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/links/LinkableRegistry.java
@@ -2,9 +2,10 @@ package org.texttechnologylab.models.corpus.links;
 
 import org.texttechnologylab.models.viewModels.link.LinkableViewModel;
 
+import java.util.Map;
 import java.util.WeakHashMap;
 
 public class LinkableRegistry {
     // TODO: With millions of links cached, this might cause serious RAM problems (but the WeakHashMap should be cleaned up automatically, it's quiet fast at deleting).
-    public static final WeakHashMap<Object, LinkableViewModel> nodeMap = new WeakHashMap<>();
+    public static final Map<Object, LinkableViewModel> nodeMap = new WeakHashMap<>();
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatMessage.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatMessage.java
@@ -10,7 +10,7 @@ public class RAGChatMessage {
     private Roles role;
     private String message;
     private DateTime created;
-    private ArrayList<Document> contextDocuments;
+    private List<Document> contextDocuments;
 
     /**
      * This is the prompt we send to our rag webserver. It differs from
@@ -24,11 +24,11 @@ public class RAGChatMessage {
         this.contextDocuments = new ArrayList<>();
     }
 
-    public ArrayList<Document> getContextDocuments() {
+    public List<Document> getContextDocuments() {
         return contextDocuments;
     }
 
-    public void setContextDocuments(ArrayList<Document> contextDocuments) {
+    public void setContextDocuments(List<Document> contextDocuments) {
         this.contextDocuments = contextDocuments;
     }
 

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatState.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatState.java
@@ -1,12 +1,9 @@
 package org.texttechnologylab.models.rag;
 
-import org.apache.uima.cas.text.Language;
 import org.joda.time.DateTime;
-import org.texttechnologylab.models.corpus.Document;
 import org.texttechnologylab.utils.SupportedLanguages;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -14,7 +11,7 @@ public class RAGChatState {
     private UUID chatId;
     private String model;
     private DateTime started;
-    private ArrayList<RAGChatMessage> messages;
+    private List<RAGChatMessage> messages;
     private SupportedLanguages language;
     public RAGChatState(){
         this.started = DateTime.now();

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/search/DocumentSearchResult.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/search/DocumentSearchResult.java
@@ -2,95 +2,96 @@ package org.texttechnologylab.models.search;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class DocumentSearchResult {
 
     private int documentCount;
-    private ArrayList<Integer> documentIds;
-    private ArrayList<Integer> documentHits;
-    private HashMap<Integer, ArrayList<PageSnippet>> searchSnippets;
-    private HashMap<Long, ArrayList<PageSnippet>> searchSnippetsDocIdToSnippet;
-    private HashMap<Integer, Float> searchRanks;
+    private List<Integer> documentIds;
+    private List<Integer> documentHits;
+    private Map<Integer, List<PageSnippet>> searchSnippets;
+    private Map<Long, List<PageSnippet>> searchSnippetsDocIdToSnippet;
+    private Map<Integer, Float> searchRanks;
 
-    private ArrayList<AnnotationSearchResult> foundNamedEntities = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundTimes = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundTaxons = new ArrayList<>();
+    private List<AnnotationSearchResult> foundNamedEntities = new ArrayList<>();
+    private List<AnnotationSearchResult> foundTimes = new ArrayList<>();
+    private List<AnnotationSearchResult> foundTaxons = new ArrayList<>();
 
-    private ArrayList<AnnotationSearchResult> foundScopes = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundXscopes = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundEvents = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundFoci = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundCues = new ArrayList<>();
+    private List<AnnotationSearchResult> foundScopes = new ArrayList<>();
+    private List<AnnotationSearchResult> foundXscopes = new ArrayList<>();
+    private List<AnnotationSearchResult> foundEvents = new ArrayList<>();
+    private List<AnnotationSearchResult> foundFoci = new ArrayList<>();
+    private List<AnnotationSearchResult> foundCues = new ArrayList<>();
 
 
     public DocumentSearchResult(int documentCount,
-                                ArrayList<Integer> documentIds) {
+                                List<Integer> documentIds) {
         this.documentCount = documentCount;
         this.documentIds = documentIds;
     }
 
-    public HashMap<Long, ArrayList<PageSnippet>> getSearchSnippetsDocIdToSnippet() {
+    public Map<Long, List<PageSnippet>> getSearchSnippetsDocIdToSnippet() {
         return searchSnippetsDocIdToSnippet;
     }
 
-    public void setSearchSnippetsDocIdToSnippet(HashMap<Long, ArrayList<PageSnippet>> searchSnippetsDocIdToSnippet) {
+    public void setSearchSnippetsDocIdToSnippet(Map<Long, List<PageSnippet>> searchSnippetsDocIdToSnippet) {
         this.searchSnippetsDocIdToSnippet = searchSnippetsDocIdToSnippet;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundScopes() {
+    public List<AnnotationSearchResult> getFoundScopes() {
         return foundScopes;
     }
 
-    public void setFoundScopes(ArrayList<AnnotationSearchResult> foundScopes) {
+    public void setFoundScopes(List<AnnotationSearchResult> foundScopes) {
         this.foundScopes = foundScopes;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundXscopes() {
+    public List<AnnotationSearchResult> getFoundXscopes() {
         return foundXscopes;
     }
 
-    public void setFoundXscopes(ArrayList<AnnotationSearchResult> foundXscopes) {
+    public void setFoundXscopes(List<AnnotationSearchResult> foundXscopes) {
         this.foundXscopes = foundXscopes;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundEvents() {
+    public List<AnnotationSearchResult> getFoundEvents() {
         return foundEvents;
     }
 
-    public void setFoundEvents(ArrayList<AnnotationSearchResult> foundEvents) {
+    public void setFoundEvents(List<AnnotationSearchResult> foundEvents) {
         this.foundEvents = foundEvents;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundFoci() {
+    public List<AnnotationSearchResult> getFoundFoci() {
         return foundFoci;
     }
 
-    public void setFoundFoci(ArrayList<AnnotationSearchResult> foundFoci) {
+    public void setFoundFoci(List<AnnotationSearchResult> foundFoci) {
         this.foundFoci = foundFoci;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundCues() {
+    public List<AnnotationSearchResult> getFoundCues() {
         return foundCues;
     }
 
-    public void setFoundCues(ArrayList<AnnotationSearchResult> foundCues) {
+    public void setFoundCues(List<AnnotationSearchResult> foundCues) {
         this.foundCues = foundCues;
     }
 
-    public HashMap<Integer, Float> getSearchRanks() {
+    public Map<Integer, Float> getSearchRanks() {
         return searchRanks;
     }
 
-    public void setSearchRanks(HashMap<Integer, Float> searchRanks) {
+    public void setSearchRanks(Map<Integer, Float> searchRanks) {
         this.searchRanks = searchRanks;
     }
 
-    public HashMap<Integer, ArrayList<PageSnippet>> getSearchSnippets() {
+    public Map<Integer, List<PageSnippet>> getSearchSnippets() {
         return searchSnippets;
     }
 
-    public void setSearchSnippets(HashMap<Integer, ArrayList<PageSnippet>> searchSnippets) {
+    public void setSearchSnippets(Map<Integer, List<PageSnippet>> searchSnippets) {
         this.searchSnippets = searchSnippets;
     }
 
@@ -98,39 +99,39 @@ public class DocumentSearchResult {
         this.documentCount = documentCount;
     }
 
-    public void setDocumentIds(ArrayList<Integer> documentIds) {
+    public void setDocumentIds(List<Integer> documentIds) {
         this.documentIds = documentIds;
     }
 
-    public ArrayList<Integer> getDocumentHits() {
+    public List<Integer> getDocumentHits() {
         return documentHits;
     }
 
-    public void setDocumentHits(ArrayList<Integer> documentHits) {
+    public void setDocumentHits(List<Integer> documentHits) {
         this.documentHits = documentHits;
     }
 
-    public void setFoundTimes(ArrayList<AnnotationSearchResult> foundTimes) {
+    public void setFoundTimes(List<AnnotationSearchResult> foundTimes) {
         this.foundTimes = foundTimes;
     }
 
-    public void setFoundTaxons(ArrayList<AnnotationSearchResult> foundTaxons) {
+    public void setFoundTaxons(List<AnnotationSearchResult> foundTaxons) {
         this.foundTaxons = foundTaxons;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundTimes() {
+    public List<AnnotationSearchResult> getFoundTimes() {
         return foundTimes;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundTaxons() {
+    public List<AnnotationSearchResult> getFoundTaxons() {
         return foundTaxons;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundNamedEntities() {
+    public List<AnnotationSearchResult> getFoundNamedEntities() {
         return foundNamedEntities;
     }
 
-    public void setFoundNamedEntities(ArrayList<AnnotationSearchResult> foundNamedEntities) {
+    public void setFoundNamedEntities(List<AnnotationSearchResult> foundNamedEntities) {
         this.foundNamedEntities = foundNamedEntities;
     }
 
@@ -138,7 +139,7 @@ public class DocumentSearchResult {
         return documentCount;
     }
 
-    public ArrayList<Integer> getDocumentIds() {
+    public List<Integer> getDocumentIds() {
         return documentIds;
     }
 

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
@@ -771,7 +771,7 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
                 allAnnos.addAll(xscopes);
                 allAnnos.addAll(scopes);
 
-                HashMap<Long, ArrayList<PageSnippet>> foundSnippets = new HashMap<>();
+                HashMap<Long, List<PageSnippet>> foundSnippets = new HashMap<>();
                 TreeMap<Long, List<AnnotationSearchResult>> negSorted = new TreeMap<>();
                 for (AnnotationSearchResult anno : allAnnos) {
                     if (negSorted.get(anno.getAdditionalId()) == null) {
@@ -782,7 +782,7 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
                     }
                 }
                 for (Long negId : negSorted.keySet()) {
-                    List<ArrayList<Integer>> offsetList = new ArrayList<>();
+                    List<List<Integer>> offsetList = new ArrayList<>();
                     int minBegin = 999999999;
                     int maxEnd = 0;
                     for (AnnotationSearchResult anno : negSorted.get(negId)) {
@@ -798,7 +798,7 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
                         offsetList.add(offsetsTemp);
                     }
                     try {
-                        for (ArrayList<Integer> pair : offsetList) {
+                        for (List<Integer> pair : offsetList) {
                             for (int i = 0; i < pair.size(); i++) {
                                 pair.set(i, pair.get(i) - Math.max(minBegin - 100, 0));
                             }
@@ -888,13 +888,13 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
                         // The found text snippets.
                         var gson = new Gson();
                         var resultSet = result.getArray("snippets_found").getResultSet();
-                        var foundSnippets = new HashMap<Integer, ArrayList<PageSnippet>>();
+                        var foundSnippets = new HashMap<Integer, List<PageSnippet>>();
                         // Snippets are the snippet text and the page_id to which this snippet belongs. They are json objects
                         while (resultSet.next()) {
                             var idx = resultSet.getInt(1) - 1;
-                            ArrayList<ArrayList<PageSnippet>> pageSnippet = gson.fromJson(
+                            ArrayList<List<PageSnippet>> pageSnippet = gson.fromJson(
                                     resultSet.getString(2),
-                                    new TypeToken<ArrayList<ArrayList<PageSnippet>>>() {
+                                    new TypeToken<List<List<PageSnippet>>>() {
                                     }.getType());
                             foundSnippets.put(idx, pageSnippet.getFirst());
                         }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/utils/FreemarkerUtils.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/utils/FreemarkerUtils.java
@@ -10,17 +10,17 @@ import java.util.List;
 
 
 public class FreemarkerUtils {
-    public static List<ArrayList<Integer>> convertToNestedIntegerList(TemplateSequenceModel outerSeq)
+    public static List<List<Integer>> convertToNestedIntegerList(TemplateSequenceModel outerSeq)
             throws TemplateModelException {
 
-        List<ArrayList<Integer>> result = new ArrayList<>();
+        List<List<Integer>> result = new ArrayList<>();
 
         for (int i = 0; i < outerSeq.size(); i++) {
             TemplateModel innerModel = outerSeq.get(i);
 
             if (innerModel instanceof TemplateSequenceModel) {
                 TemplateSequenceModel innerSeq = (TemplateSequenceModel) innerModel;
-                ArrayList<Integer> innerList = new ArrayList<>();
+                List<Integer> innerList = new ArrayList<>();
 
                 for (int j = 0; j < innerSeq.size(); j++) {
                     TemplateModel valueModel = innerSeq.get(j);

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/utils/StringUtils.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/utils/StringUtils.java
@@ -1,9 +1,6 @@
 package org.texttechnologylab.utils;
 
 
-import org.texttechnologylab.models.UIMAAnnotation;
-import org.texttechnologylab.models.corpus.Page;
-
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -295,12 +292,12 @@ public class StringUtils {
         return result.toString();
     }
 
-    public static String addBoldTags(String input, List<ArrayList<Integer>> offsets) {
+    public static String addBoldTags(String input, List<List<Integer>> offsets) {
         StringBuilder result = new StringBuilder();
         int idx = 0;
         for (char c : input.toCharArray()) {
             boolean inBold = false;
-            for (ArrayList<Integer> offset : offsets) {
+            for (List<Integer> offset : offsets) {
                 if (idx < offset.getLast() && offset.getFirst() <= idx) {
                     inBold = true;
                     break;

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/utils/TokenUtils.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/utils/TokenUtils.java
@@ -7,13 +7,13 @@ import java.util.List;
 
 
 public class TokenUtils {
-    public static ArrayList<ArrayList<Token>> findMaximalSpans(List<Token> tokens) {
-        ArrayList<ArrayList<Token>> spans = new ArrayList<>();
+    public static List<List<Token>> findMaximalSpans(List<Token> tokens) {
+        List<List<Token>> spans = new ArrayList<>();
         if (tokens.isEmpty()) return spans;
 
         // Sort tokens by start position (optional if already sorted)
         tokens.sort((t1, t2) -> Integer.compare(t1.getBegin(), t2.getEnd()));
-        ArrayList<Token> currentSpan = new ArrayList<>();
+        List<Token> currentSpan = new ArrayList<>();
         currentSpan.add(tokens.getFirst());
 
         for (int i = 1; i < tokens.size(); i++) {

--- a/uce.portal/uce.corpus-importer/pom.xml
+++ b/uce.portal/uce.corpus-importer/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.texttechnologylab</groupId>
             <artifactId>uce.common</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Global reference -->

--- a/uce.portal/uce.corpus-importer/pom.xml
+++ b/uce.portal/uce.corpus-importer/pom.xml
@@ -75,7 +75,7 @@
 
         <!-- local projects-->
         <dependency>
-            <groupId>org.texttechnologylab</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>uce.common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/uce.portal/uce.corpus-importer/pom.xml
+++ b/uce.portal/uce.corpus-importer/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javaVersion>21</javaVersion>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>

--- a/uce.portal/uce.corpus-importer/src/main/java/org/texttechnologylab/Importer.java
+++ b/uce.portal/uce.corpus-importer/src/main/java/org/texttechnologylab/Importer.java
@@ -1169,12 +1169,12 @@ public class Importer {
      */
     public void setCompleteNegations(Document document, JCas jCas) {
         // All Annotations
-        ArrayList<CompleteNegation> cNegationsTotal = new ArrayList<>();
-        ArrayList<Cue> cuesTotal = new ArrayList<>();
-        ArrayList<Scope> scopesTotal = new ArrayList<>();
-        ArrayList<XScope> xScopesTotal = new ArrayList<>();
-        ArrayList<Focus> focusesTotal = new ArrayList<>();
-        ArrayList<Event> eventsTotal = new ArrayList<>();
+        List<CompleteNegation> cNegationsTotal = new ArrayList<>();
+        List<Cue> cuesTotal = new ArrayList<>();
+        List<Scope> scopesTotal = new ArrayList<>();
+        List<XScope> xScopesTotal = new ArrayList<>();
+        List<Focus> focusesTotal = new ArrayList<>();
+        List<Event> eventsTotal = new ArrayList<>();
 
         //iterate over each negation
         for (org.texttechnologylab.annotation.negation.CompleteNegation negation : jCas.select(org.texttechnologylab.annotation.negation.CompleteNegation.class)) {
@@ -1195,13 +1195,13 @@ public class Importer {
             cue.setCoveredText(cue.getCoveredText(jCas.getDocumentText()));
 
             // -> partially set scopes, xscopes, focuses and events
-            ArrayList<Scope> scopes = new ArrayList<>();
-            ArrayList<XScope> xScopes = new ArrayList<>();
-            ArrayList<Focus> focuses = new ArrayList<>();
-            ArrayList<Event> events = new ArrayList<>();
+            List<Scope> scopes = new ArrayList<>();
+            List<XScope> xScopes = new ArrayList<>();
+            List<Focus> focuses = new ArrayList<>();
+            List<Event> events = new ArrayList<>();
             if (eventTL != null) {
-                ArrayList<ArrayList<Token>> spans = TokenUtils.findMaximalSpans(eventTL.stream().collect(Collectors.toCollection(ArrayList::new)));
-                for (ArrayList<Token> span : spans) {
+                List<List<Token>> spans = TokenUtils.findMaximalSpans(eventTL.stream().collect(Collectors.toCollection(ArrayList::new)));
+                for (List<Token> span : spans) {
                     // -> fully set event
                     Event event = new Event(span.getFirst().getBegin(), span.getLast().getEnd());
                     event.setDocument(document);
@@ -1211,8 +1211,8 @@ public class Importer {
                 }
             }
             if (scopeTL != null) {
-                ArrayList<ArrayList<Token>> spans = TokenUtils.findMaximalSpans(scopeTL.stream().collect(Collectors.toCollection(ArrayList::new)));
-                for (ArrayList<Token> span : spans) {
+                List<List<Token>> spans = TokenUtils.findMaximalSpans(scopeTL.stream().collect(Collectors.toCollection(ArrayList::new)));
+                for (List<Token> span : spans) {
                     // -> fully set scope
                     Scope scope = new Scope(span.getFirst().getBegin(), span.getLast().getEnd());
                     scope.setDocument(document);
@@ -1222,8 +1222,8 @@ public class Importer {
                 }
             }
             if (xscopeTL != null) {
-                ArrayList<ArrayList<Token>> spans = TokenUtils.findMaximalSpans(xscopeTL.stream().collect(Collectors.toCollection(ArrayList::new)));
-                for (ArrayList<Token> span : spans) {
+                List<List<Token>> spans = TokenUtils.findMaximalSpans(xscopeTL.stream().collect(Collectors.toCollection(ArrayList::new)));
+                for (List<Token> span : spans) {
                     // -> fully set xscope
                     XScope xscope = new XScope(span.getFirst().getBegin(), span.getLast().getEnd());
                     xscope.setDocument(document);
@@ -1233,8 +1233,8 @@ public class Importer {
                 }
             }
             if (focusTL != null) {
-                ArrayList<ArrayList<Token>> spans = TokenUtils.findMaximalSpans(focusTL.stream().collect(Collectors.toCollection(ArrayList::new)));
-                for (ArrayList<Token> span : spans) {
+                List<List<Token>> spans = TokenUtils.findMaximalSpans(focusTL.stream().collect(Collectors.toCollection(ArrayList::new)));
+                for (List<Token> span : spans) {
                     // -> fully set focus
                     Focus focus = new Focus(span.getFirst().getBegin(), span.getLast().getEnd());
                     focus.setDocument(document);

--- a/uce.portal/uce.search/pom.xml
+++ b/uce.portal/uce.search/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.texttechnologylab</groupId>
             <artifactId>uce.common</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/uce.portal/uce.search/pom.xml
+++ b/uce.portal/uce.search/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.texttechnologylab</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>uce.common</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/uce.portal/uce.search/pom.xml
+++ b/uce.portal/uce.search/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javaVersion>21</javaVersion>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>

--- a/uce.portal/uce.search/src/main/java/org/texttechnologylab/CompleteNegationSearchState.java
+++ b/uce.portal/uce.search/src/main/java/org/texttechnologylab/CompleteNegationSearchState.java
@@ -3,57 +3,58 @@ package org.texttechnologylab;
 import org.texttechnologylab.models.search.SearchType;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class CompleteNegationSearchState extends SearchState{
 
-    private ArrayList<String> cue = new ArrayList<>();
-    private ArrayList<String> scope = new ArrayList<>();
-    private ArrayList<String> xscope = new ArrayList<>();
-    private ArrayList<String> focus = new ArrayList<>();
-    private ArrayList<String> event = new ArrayList<>();
+    private List<String> cue = new ArrayList<>();
+    private List<String> scope = new ArrayList<>();
+    private List<String> xscope = new ArrayList<>();
+    private List<String> focus = new ArrayList<>();
+    private List<String> event = new ArrayList<>();
 
     public CompleteNegationSearchState(SearchType searchType) {
         super(searchType);
     }
 
 
-    public ArrayList<String> getCue() {
+    public List<String> getCue() {
         return cue;
     }
 
-    public void setCue(ArrayList<String> cue) {
+    public void setCue(List<String> cue) {
         this.cue = cue;
     }
 
-    public ArrayList<String> getScope() {
+    public List<String> getScope() {
         return scope;
     }
 
-    public void setScope(ArrayList<String> scope) {
+    public void setScope(List<String> scope) {
         this.scope = scope;
     }
 
-    public ArrayList<String> getXscope() {
+    public List<String> getXscope() {
         return xscope;
     }
 
-    public void setXscope(ArrayList<String> xscope) {
+    public void setXscope(List<String> xscope) {
         this.xscope = xscope;
     }
 
-    public ArrayList<String> getFocus() {
+    public List<String> getFocus() {
         return focus;
     }
 
-    public void setFocus(ArrayList<String> focus) {
+    public void setFocus(List<String> focus) {
         this.focus = focus;
     }
 
-    public ArrayList<String> getEvent() {
+    public List<String> getEvent() {
         return event;
     }
 
-    public void setEvent(ArrayList<String> event) {
+    public void setEvent(List<String> event) {
         this.event = event;
     }
 }

--- a/uce.portal/uce.search/src/main/java/org/texttechnologylab/LayeredSearch.java
+++ b/uce.portal/uce.search/src/main/java/org/texttechnologylab/LayeredSearch.java
@@ -12,7 +12,6 @@ import org.texttechnologylab.services.JenaSparqlService;
 import org.texttechnologylab.services.PostgresqlDataInterface_Impl;
 import org.texttechnologylab.utils.StringUtils;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -71,7 +70,7 @@ public class LayeredSearch extends CacheItem {
     /**
      * Takes in a layer of any depth and updates the corresponding layered search with the information.
      */
-    public void updateLayers(ArrayList<LayeredSearchLayerDto> layerDtos) throws DatabaseOperationException {
+    public void updateLayers(List<LayeredSearchLayerDto> layerDtos) throws DatabaseOperationException {
         for (var layer : layerDtos) {
             var existingLayer = this.layers.stream().filter(l -> l.getDepth() == layer.getDepth()).findFirst();
             // If we have a layer of that depth, check if its dirty (the slots changed its value)

--- a/uce.portal/uce.search/src/main/java/org/texttechnologylab/SearchCompleteNegation.java
+++ b/uce.portal/uce.search/src/main/java/org/texttechnologylab/SearchCompleteNegation.java
@@ -101,7 +101,7 @@ public class SearchCompleteNegation implements Search {
      *
      * @param argList
      */
-    private ArrayList<String> preprocess_args(ArrayList<String> argList) {
+    private List<String> preprocess_args(List<String> argList) {
         return new ArrayList<String>(argList.stream().map(a -> a
                         .trim()
                         .replace(".", "")

--- a/uce.portal/uce.search/src/main/java/org/texttechnologylab/SearchState.java
+++ b/uce.portal/uce.search/src/main/java/org/texttechnologylab/SearchState.java
@@ -42,23 +42,23 @@ public class SearchState extends CacheItem {
     private OrderByColumn orderBy = OrderByColumn.RANK;
     private KeywordInContextState keywordInContextState;
 
-    private ArrayList<AnnotationSearchResult> foundNamedEntities = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundTimes = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundTaxons = new ArrayList<>();
+    private List<AnnotationSearchResult> foundNamedEntities = new ArrayList<>();
+    private List<AnnotationSearchResult> foundTimes = new ArrayList<>();
+    private List<AnnotationSearchResult> foundTaxons = new ArrayList<>();
 
     // Negation
-    private ArrayList<AnnotationSearchResult> foundScopes = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundCues = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundXScopes = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundFoci = new ArrayList<>();
-    private ArrayList<AnnotationSearchResult> foundEvents = new ArrayList<>();
+    private List<AnnotationSearchResult> foundScopes = new ArrayList<>();
+    private List<AnnotationSearchResult> foundCues = new ArrayList<>();
+    private List<AnnotationSearchResult> foundXScopes = new ArrayList<>();
+    private List<AnnotationSearchResult> foundFoci = new ArrayList<>();
+    private List<AnnotationSearchResult> foundEvents = new ArrayList<>();
 
 
 
     /**
      * This is only filled when the search layer contains embeddings
      */
-    private ArrayList<DocumentChunkEmbeddingSearchResult> foundDocumentChunkEmbeddings;
+    private List<DocumentChunkEmbeddingSearchResult> foundDocumentChunkEmbeddings;
 
     private String primarySearchLayer;
 
@@ -71,9 +71,9 @@ public class SearchState extends CacheItem {
      * This is currently not used.
      */
     private List<Integer> currentDocumentHits;
-    private HashMap<Integer, ArrayList<PageSnippet>> documentIdxToSnippet;
-    private HashMap<Long, ArrayList<PageSnippet>> documentIdToSnippet;
-    private HashMap<Integer, Float> documentIdxToRank;
+    private Map<Integer, List<PageSnippet>> documentIdxToSnippet;
+    private Map<Long, List<PageSnippet>> documentIdToSnippet;
+    private Map<Integer, Float> documentIdxToRank;
 
     public SearchState(SearchType searchType) {
         this.searchType = searchType;
@@ -143,7 +143,7 @@ public class SearchState extends CacheItem {
         return -1;
     }
 
-    public void setDocumentIdxToRank(HashMap<Integer, Float> documentIdxToRank) {
+    public void setDocumentIdxToRank(Map<Integer, Float> documentIdxToRank) {
         this.documentIdxToRank = documentIdxToRank;
     }
 
@@ -159,13 +159,13 @@ public class SearchState extends CacheItem {
         this.uceMetadataFilters = uceMetadataFilters;
     }
 
-    public ArrayList<PageSnippet> getPossibleSnippetsOfDocumentIdx(Integer idx) {
+    public List<PageSnippet> getPossibleSnippetsOfDocumentIdx(Integer idx) {
         if (this.documentIdxToSnippet != null && this.documentIdxToSnippet.containsKey(idx))
             return this.documentIdxToSnippet.get(idx);
         return null;
     }
 
-    public ArrayList<PageSnippet> getPossibleSnippetsOfDocumentId(long id) {
+    public List<PageSnippet> getPossibleSnippetsOfDocumentId(long id) {
         if (this.documentIdToSnippet != null && this.documentIdToSnippet.containsKey(id))
             return this.documentIdToSnippet.get(id);
         return null;
@@ -175,7 +175,7 @@ public class SearchState extends CacheItem {
         return this.created;
     }
 
-    public void setDocumentIdxToSnippets(HashMap<Integer, ArrayList<PageSnippet>> map) {
+    public void setDocumentIdxToSnippets(Map<Integer, List<PageSnippet>> map) {
         this.documentIdxToSnippet = map;
 
         // Whenever we set documents within a fulltext search, we should have found snippets.
@@ -193,7 +193,7 @@ public class SearchState extends CacheItem {
         }
     }
 
-    public void setDocumentIdToSnippets(HashMap<Long, ArrayList<PageSnippet>> map) {
+    public void setDocumentIdToSnippets(Map<Long, List<PageSnippet>> map) {
         this.documentIdToSnippet = map;
 
         // Whenever we set documents within a fulltext search, we should have found snippets.
@@ -247,19 +247,19 @@ public class SearchState extends CacheItem {
         this.searchType = searchType;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundTimes() {
+    public List<AnnotationSearchResult> getFoundTimes() {
         return foundTimes;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundTaxons() {
+    public List<AnnotationSearchResult> getFoundTaxons() {
         return foundTaxons;
     }
 
-    public ArrayList<DocumentChunkEmbeddingSearchResult> getFoundDocumentChunkEmbeddings() {
+    public List<DocumentChunkEmbeddingSearchResult> getFoundDocumentChunkEmbeddings() {
         return foundDocumentChunkEmbeddings;
     }
 
-    public void setFoundDocumentChunkEmbeddings(ArrayList<DocumentChunkEmbeddingSearchResult> foundDocumentChunkEmbeddings) {
+    public void setFoundDocumentChunkEmbeddings(List<DocumentChunkEmbeddingSearchResult> foundDocumentChunkEmbeddings) {
         this.foundDocumentChunkEmbeddings = foundDocumentChunkEmbeddings;
     }
 
@@ -350,28 +350,28 @@ public class SearchState extends CacheItem {
         return foundNamedEntities.stream().filter(ne -> ne.getInfo().equals(type)).skip(skip).limit(take).toList();
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundNamedEntities() {
+    public List<AnnotationSearchResult> getFoundNamedEntities() {
         return foundNamedEntities;
     }
 
-    public void setFoundNamedEntities(ArrayList<AnnotationSearchResult> foundNamedEntities) {
+    public void setFoundNamedEntities(List<AnnotationSearchResult> foundNamedEntities) {
         // We have so much wrong annotations like . or a - dont show those which are shorter than 2 characters.
         this.foundNamedEntities = new ArrayList<>(foundNamedEntities.stream().filter(e -> e.getCoveredText().length() > 2).sorted(Comparator.comparingInt(AnnotationSearchResult::getOccurrences).reversed()).toList());
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundTimes(int skip, int take) {
+    public List<AnnotationSearchResult> getFoundTimes(int skip, int take) {
         return new ArrayList<>(foundTimes.stream().skip(skip).limit(take).toList());
     }
 
-    public void setFoundTimes(ArrayList<AnnotationSearchResult> foundTimes) {
+    public void setFoundTimes(List<AnnotationSearchResult> foundTimes) {
         this.foundTimes = new ArrayList<>(foundTimes.stream().filter(e -> e.getCoveredText().length() > 2).sorted(Comparator.comparingInt(AnnotationSearchResult::getOccurrences).reversed()).toList());
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundTaxons(int skip, int take) {
+    public List<AnnotationSearchResult> getFoundTaxons(int skip, int take) {
         return new ArrayList<>(foundTaxons.stream().skip(skip).limit(take).toList());
     }
 
-    public void setFoundTaxons(ArrayList<AnnotationSearchResult> foundTaxons) {
+    public void setFoundTaxons(List<AnnotationSearchResult> foundTaxons) {
         this.foundTaxons = new ArrayList<>(foundTaxons.stream().filter(e -> e.getCoveredText().length() > 2).sorted(Comparator.comparingInt(AnnotationSearchResult::getOccurrences).reversed()).toList());
     }
 
@@ -450,43 +450,43 @@ public class SearchState extends CacheItem {
         this.take = take;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundScopes(int skip, int take) {
+    public List<AnnotationSearchResult> getFoundScopes(int skip, int take) {
         return new ArrayList<>(foundScopes.stream().skip(skip).limit(take).toList());
     }
 
-    public void setFoundScopes(ArrayList<AnnotationSearchResult> foundScopes) {
+    public void setFoundScopes(List<AnnotationSearchResult> foundScopes) {
         this.foundScopes = foundScopes;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundCues(int skip, int take) {
+    public List<AnnotationSearchResult> getFoundCues(int skip, int take) {
         return new ArrayList<>(foundCues.stream().skip(skip).limit(take).toList());
     }
 
-    public void setFoundCues(ArrayList<AnnotationSearchResult> foundCues) {
+    public void setFoundCues(List<AnnotationSearchResult> foundCues) {
         this.foundCues = foundCues;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundXScopes(int skip, int take) {
+    public List<AnnotationSearchResult> getFoundXScopes(int skip, int take) {
         return new ArrayList<>(foundXScopes.stream().skip(skip).limit(take).toList());
     }
 
-    public void setFoundXScopes(ArrayList<AnnotationSearchResult> foundXScopes) {
+    public void setFoundXScopes(List<AnnotationSearchResult> foundXScopes) {
         this.foundXScopes = foundXScopes;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundFoci(int skip, int take) {
+    public List<AnnotationSearchResult> getFoundFoci(int skip, int take) {
         return new ArrayList<>(foundFoci.stream().skip(skip).limit(take).toList());
     }
 
-    public void setFoundFoci(ArrayList<AnnotationSearchResult> foundFoci) {
+    public void setFoundFoci(List<AnnotationSearchResult> foundFoci) {
         this.foundFoci = foundFoci;
     }
 
-    public ArrayList<AnnotationSearchResult> getFoundEvents(int skip, int take) {
+    public List<AnnotationSearchResult> getFoundEvents(int skip, int take) {
         return new ArrayList<>(foundEvents.stream().skip(skip).limit(take).toList());
     }
 
-    public void setFoundEvents(ArrayList<AnnotationSearchResult> foundEvents) {
+    public void setFoundEvents(List<AnnotationSearchResult> foundEvents) {
         this.foundEvents = foundEvents;
     }
 

--- a/uce.portal/uce.search/src/main/java/org/texttechnologylab/Search_DefaultImpl.java
+++ b/uce.portal/uce.search/src/main/java/org/texttechnologylab/Search_DefaultImpl.java
@@ -35,7 +35,7 @@ public class Search_DefaultImpl implements Search {
     private RAGService ragService;
     private JenaSparqlService jenaSparqlService;
     public static final String[] QUERY_OPERATORS = {"&", "|", "!", "<->", "(", ")"};
-    private Pair<String, ArrayList<EnrichedSearchToken>> enrichment;
+    private Pair<String, List<EnrichedSearchToken>> enrichment;
 
     /**
      * Creates a new instance of the Search_DefaultImpl, throws exceptions if components couldn't be inited.

--- a/uce.portal/uce.search/src/main/java/org/texttechnologylab/Search_SemanticRoleImpl.java
+++ b/uce.portal/uce.search/src/main/java/org/texttechnologylab/Search_SemanticRoleImpl.java
@@ -3,11 +3,9 @@ package org.texttechnologylab;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.texttechnologylab.config.CorpusConfig;
 import org.texttechnologylab.exceptions.ExceptionUtils;
 import org.texttechnologylab.models.search.DocumentSearchResult;
-import org.texttechnologylab.models.search.SearchLayer;
 import org.texttechnologylab.models.search.SearchType;
 import org.texttechnologylab.services.PostgresqlDataInterface_Impl;
 
@@ -16,6 +14,7 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * The search logic object for Semantic Role Search.
@@ -37,9 +36,9 @@ public class Search_SemanticRoleImpl implements Search {
 
     public Search_SemanticRoleImpl(ApplicationContext serviceContext,
                                    long corpusId,
-                                   ArrayList<String> arg0,
-                                   ArrayList<String> arg1,
-                                   ArrayList<String> argm,
+                                   List<String> arg0,
+                                   List<String> arg1,
+                                   List<String> argm,
                                    String verb) {
         this.searchState = new SemanticRoleSearchState(SearchType.SEMANTICROLE);
         setDefaultSearchStateParameters(serviceContext, corpusId);
@@ -179,7 +178,7 @@ public class Search_SemanticRoleImpl implements Search {
      *
      * @param argList
      */
-    private ArrayList<String> preprocess_args(ArrayList<String> argList) {
+    private List<String> preprocess_args(List<String> argList) {
         return new ArrayList<String>(argList.stream().map(a -> a
                         .trim()
                         .replace(".", "")

--- a/uce.portal/uce.search/src/main/java/org/texttechnologylab/SemanticRoleSearchState.java
+++ b/uce.portal/uce.search/src/main/java/org/texttechnologylab/SemanticRoleSearchState.java
@@ -3,48 +3,49 @@ package org.texttechnologylab;
 import org.texttechnologylab.models.search.SearchType;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class SemanticRoleSearchState extends SearchState{
 
-    private ArrayList<String> arg0 = new ArrayList<>();
-    private ArrayList<String> arg1 = new ArrayList<>();
-    private ArrayList<String> arg2 = new ArrayList<>();
-    private ArrayList<String> argm = new ArrayList<>();
+    private List<String> arg0 = new ArrayList<>();
+    private List<String> arg1 = new ArrayList<>();
+    private List<String> arg2 = new ArrayList<>();
+    private List<String> argm = new ArrayList<>();
     private String verb = "";
 
     public SemanticRoleSearchState(SearchType searchType) {
         super(searchType);
     }
 
-    public ArrayList<String> getArg2() {
+    public List<String> getArg2() {
         return arg2;
     }
 
-    public void setArg2(ArrayList<String> arg2) {
+    public void setArg2(List<String> arg2) {
         this.arg2 = arg2;
     }
 
-    public ArrayList<String> getArg0() {
+    public List<String> getArg0() {
         return arg0;
     }
 
-    public void setArg0(ArrayList<String> arg0) {
+    public void setArg0(List<String> arg0) {
         this.arg0 = arg0;
     }
 
-    public ArrayList<String> getArg1() {
+    public List<String> getArg1() {
         return arg1;
     }
 
-    public void setArg1(ArrayList<String> arg1) {
+    public void setArg1(List<String> arg1) {
         this.arg1 = arg1;
     }
 
-    public ArrayList<String> getArgm() {
+    public List<String> getArgm() {
         return argm;
     }
 
-    public void setArgm(ArrayList<String> argm) {
+    public void setArgm(List<String> argm) {
         this.argm = argm;
     }
 

--- a/uce.portal/uce.web/pom.xml
+++ b/uce.portal/uce.web/pom.xml
@@ -59,19 +59,19 @@
         <dependency>
             <groupId>org.texttechnologylab</groupId>
             <artifactId>uce.common</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.texttechnologylab</groupId>
             <artifactId>uce.corpus-importer</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.texttechnologylab</groupId>
             <artifactId>uce.search</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/uce.portal/uce.web/pom.xml
+++ b/uce.portal/uce.web/pom.xml
@@ -57,19 +57,19 @@
         </dependency>
 
         <dependency>
-            <groupId>org.texttechnologylab</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>uce.common</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.texttechnologylab</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>uce.corpus-importer</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.texttechnologylab</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>uce.search</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/SessionManager.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/SessionManager.java
@@ -2,17 +2,17 @@ package org.texttechnologylab;
 
 import org.texttechnologylab.cronjobs.SessionJob;
 import org.texttechnologylab.models.search.CacheItem;
-import org.texttechnologylab.models.viewModels.wiki.CachedWikiPage;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public final class SessionManager {
 
     // TODO: I think these search states can stay in RAM for a while. Everything in this SessionManager
     // gets cleaned up anyways from time to time by a cronjob
-    public static HashMap<String, CacheItem> ActiveSearches = new HashMap<>();
-    public static HashMap<String, CacheItem> ActiveLayeredSearches = new HashMap<>();
-    public static HashMap<String, CacheItem> CachedWikiPages = new HashMap<>();
+    public static Map<String, CacheItem> ActiveSearches = new HashMap<>();
+    public static Map<String, CacheItem> ActiveLayeredSearches = new HashMap<>();
+    public static Map<String, CacheItem> CachedWikiPages = new HashMap<>();
 
     public static void InitSessionManager(long cleanupInterval){
         Runnable runnable = new SessionJob(cleanupInterval);

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/cronjobs/SessionJob.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/cronjobs/SessionJob.java
@@ -6,7 +6,7 @@ import org.texttechnologylab.SessionManager;
 import org.texttechnologylab.exceptions.ExceptionUtils;
 import org.texttechnologylab.models.search.CacheItem;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class SessionJob implements Runnable {
 
@@ -42,7 +42,7 @@ public class SessionJob implements Runnable {
         }
     }
 
-    private void executeCleanupCycle(HashMap<String, CacheItem> cachedItems) {
+    private void executeCleanupCycle(Map<String, CacheItem> cachedItems) {
         var iterator = cachedItems.entrySet().iterator();
         while (iterator.hasNext()) {
             var entry = iterator.next();

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/freeMarker/Renderer.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/freeMarker/Renderer.java
@@ -5,10 +5,10 @@ import org.texttechnologylab.CustomFreeMarkerEngine;
 import org.texttechnologylab.models.Linkable;
 import org.texttechnologylab.models.UIMAAnnotation;
 import org.texttechnologylab.models.corpus.Document;
-import org.texttechnologylab.models.viewModels.link.LinkableViewModel;
 import spark.ModelAndView;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Just a helper class for rendering some FreeMarker templates.
@@ -39,7 +39,7 @@ public final class Renderer {
         return Renderer.renderToHTML(path, uiModel);
     }
 
-    public static String renderToHTML(String path, HashMap<String, Object> model){
+    public static String renderToHTML(String path, Map<String, Object> model){
         return new CustomFreeMarkerEngine(freemarkerConfig).render(new ModelAndView(model, path));
     }
 


### PR DESCRIPTION
This pull request focuses on improving type consistency by replacing `ArrayList` with the more generic `List` interface across multiple files. It also includes minor cleanups, such as removing unused imports and simplifying type declarations. The changes aim to enhance code maintainability and flexibility by adhering to best practices for using interfaces over concrete implementations.

### Type Consistency Improvements:
* Replaced `ArrayList` with `List` in method signatures, variable declarations, and return types in `uce.common` classes like `Document`, `RAGChatMessage`, `RAGChatState`, `DocumentSearchResult`, and `PostgresqlDataInterface_Impl`. This ensures better abstraction and flexibility. [[1]](diffhunk://#diff-b3f26e20e38d065fed7923cc5f180e0974a8a13a1d9585b0e6298bad3ed22a84L373-R371) [[2]](diffhunk://#diff-61a377f88179adea02d67bbbbf22e39b93d8c961ef9da6febfa090f5d079c8a0L13-R13) [[3]](diffhunk://#diff-715afbbd4a251503a410e5951439802e4c24d7b0563aff8a9e1cc2e718d33c4fR5-R142) [[4]](diffhunk://#diff-05c4bcc34a958b80bac424dc68fdc1a2d769590961d40be4fc152a3b871785efL891-R897)
* Updated utility classes such as `FreemarkerUtils`, `StringUtils`, and `TokenUtils` to use `List` instead of `ArrayList` for nested structures and processing logic. [[1]](diffhunk://#diff-c6a8444c57566d123a74590365c58dc53a440309e3ef329edb746fff444fb39fL13-R23) [[2]](diffhunk://#diff-85b94cf3b2d6015210700f94e7649b6a58deab49626b2ea6ea2f4f09bf28416dL298-R300) [[3]](diffhunk://#diff-8b6fe1e9bc6050528a7870d522cd03f925aa99dbe1d6576cb7157747544e3a83L10-R16)

### Code Cleanup:
* Removed unused imports in `Document`, `StringUtils`, and `RAGChatState` to reduce clutter and improve readability. [[1]](diffhunk://#diff-b3f26e20e38d065fed7923cc5f180e0974a8a13a1d9585b0e6298bad3ed22a84L18-L21) [[2]](diffhunk://#diff-85b94cf3b2d6015210700f94e7649b6a58deab49626b2ea6ea2f4f09bf28416dL4-L6) [[3]](diffhunk://#diff-5bed57170ee643f5f58efc65ea12c19b1c8c172a1992b226b768e9bcbcc4d5f0L3-R14)
* Simplified type declarations in `LinkableRegistry` by using the `Map` interface for `nodeMap` while retaining `WeakHashMap` as the implementation.

### Minor Adjustments:
* Adjusted type usage in `HibernateConf` by replacing `HashMap` with `Map` for configuration settings, aligning with the principle of programming to an interface.
* Updated nested list processing in methods such as `getFullTextSnippetAnnotationOffset` and `completeNegationSearchForDocuments` to use `List<List<Integer>>` for consistency. [[1]](diffhunk://#diff-b3f26e20e38d065fed7923cc5f180e0974a8a13a1d9585b0e6298bad3ed22a84L383-R393) [[2]](diffhunk://#diff-05c4bcc34a958b80bac424dc68fdc1a2d769590961d40be4fc152a3b871785efL785-R785)

These changes collectively improve the codebase's adherence to best practices, making it more robust and easier to maintain.